### PR TITLE
Support newer version of the CF CLI

### DIFF
--- a/.bluemix/pipeline.yml
+++ b/.bluemix/pipeline.yml
@@ -140,7 +140,7 @@ stages:
       cf set-env $TEMP_APP_NAME WORKSPACE_ID $WORKSPACE_ID
       cf start $TEMP_APP_NAME
       cf apps | grep $TEMP_APP_NAME
-      url=$(cf app $TEMP_APP_NAME | grep urls: | awk '{print $2}')
+      url=$(cf app $TEMP_APP_NAME | grep -e urls: -e routes: | awk '{print $2}')
       prefix="${TEMP_APP_NAME}."
       export DOMAIN=$( echo ${url:${#prefix}} )
       export TEMP_APP_URL="http://$url"


### PR DESCRIPTION
The latest version of the CF CLI outputs "routes:" instead of "urls:" when calling "cf app APP_NAME"